### PR TITLE
Default yt-dlp to TV client

### DIFF
--- a/server.js
+++ b/server.js
@@ -242,8 +242,8 @@ function runYtDlp(args, opts = {}) {
 }
 
 const COOKIES_PATH  = process.env.COOKIES_PATH || null;
-// You may force a client via env, e.g. YTDLP_EXTRACTOR_ARGS="youtube:player_client=web"
-const EXTRACTOR_ARGS = process.env.YTDLP_EXTRACTOR_ARGS || "";
+// Default to TV client to dodge SABR limits; override with YTDLP_EXTRACTOR_ARGS if needed.
+const EXTRACTOR_ARGS = process.env.YTDLP_EXTRACTOR_ARGS ?? "youtube:player_client=tv";
 const YTDLP_EXTRA    = process.env.YTDLP_EXTRA || "--force-ipv4"; // helps on some networks
 
 function safeBase(title) {

--- a/server.js
+++ b/server.js
@@ -579,8 +579,9 @@ app.post("/api/probe", async (req, res) => {
   const { url, fast } = req.body || {};
   if (!url || !/^https?:\/\//i.test(url)) return res.status(400).json({ error: "Invalid URL" });
   try {
+    const fastClient = (EXTRACTOR_ARGS && EXTRACTOR_ARGS.trim()) || "youtube:player_client=web";
     const r = fast
-      ? await getVideoMetaDetailed(url, "youtube:player_client=web")
+      ? await getVideoMetaDetailed(url, fastClient)
       : await getVideoMetaSmart(url);
     if (!r.ok) return res.status(400).json({ error: "Failed to read metadata", detail: r.error, code: r.code, stderr: r.stderr });
 


### PR DESCRIPTION
## Summary
- default the yt-dlp extractor args to the TV client to avoid SABR limits
- preserve the ability to override the client with YTDLP_EXTRACTOR_ARGS

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcca7766288321967b14db8f426627